### PR TITLE
[HB-6725] Set user consent when HyprMX has initialized.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.6.2.0.3
+- Set user consent when the HyprMX SDK has initialized.
+
 ### 4.6.2.0.2
 - Updated to handle recent AdFormat changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Note the first digit of every adapter version corresponds to the major version o
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
 ### 4.6.2.0.3
-- Removes a print stack trace when the user consent was being set before the HyprMX SDK was initialized.
+- Only set user consent for HyprMX if their SDK has initialized. This prevents a `java.lang.Exception: HyprEvalError ReferenceError` from happening.
 
 ### 4.6.2.0.2
 - Updated to handle recent AdFormat changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Note the first digit of every adapter version corresponds to the major version o
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
 ### 4.6.2.0.3
-- Set user consent when the HyprMX SDK has initialized.
+- Removes a print stack trace when the user consent was being set before the HyprMX SDK was initialized.
 
 ### 4.6.2.0.2
 - Updated to handle recent AdFormat changes.

--- a/HyprMXAdapter/build.gradle.kts
+++ b/HyprMXAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.6.2.0.2"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.6.2.0.3"
         buildConfigField("String", "CHARTBOOST_MEDIATION_HYPRMX_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -786,7 +786,7 @@ class HyprMXAdapter : PartnerAdapter {
      */
     private fun checkHyprMxInitStateAndRun(function: () -> Unit) {
         if (HyprMX.getInitializationState() != HyprMXState.INITIALIZATION_COMPLETE) {
-            PartnerLogController.log(CUSTOM, "Ignoring $function until HyprMX SDK has initialized.")
+            PartnerLogController.log(CUSTOM, "Cannot run $function. The HyprMX SDK has not initialized.")
             return
         }
         function()

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -781,6 +781,8 @@ class HyprMXAdapter : PartnerAdapter {
     /**
      * Checks that the HyprMX initialization state has completed. If so, then run the function;
      * otherwise, do nothing.
+     *
+     * @param function the function that will be run after the initialization state check was successful.
      */
     private fun checkHyprMxInitStateAndRun(function: () -> Unit) {
         if (HyprMX.getInitializationState() != HyprMXState.INITIALIZATION_COMPLETE) {

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -275,6 +275,7 @@ class HyprMXAdapter : PartnerAdapter {
             } successfully stored."
         )
 
+        // The HyprMX SDK throws an exception when the setConsentStatus API is used before the SDK has initialized.
         if (prefsWriteSucceeded && HyprMX.getInitializationState() == HyprMXState.INITIALIZATION_COMPLETE) {
             HyprMX.setConsentStatus(consentStatus)
         }

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -20,6 +20,7 @@ import com.hyprmx.android.sdk.consent.ConsentStatus
 import com.hyprmx.android.sdk.core.HyprMX
 import com.hyprmx.android.sdk.core.HyprMXErrors
 import com.hyprmx.android.sdk.core.HyprMXIf
+import com.hyprmx.android.sdk.core.HyprMXState
 import com.hyprmx.android.sdk.placement.Placement
 import com.hyprmx.android.sdk.placement.PlacementListener
 import com.hyprmx.android.sdk.placement.RewardedPlacementListener
@@ -274,7 +275,7 @@ class HyprMXAdapter : PartnerAdapter {
             } successfully stored."
         )
 
-        if (prefsWriteSucceeded) {
+        if (prefsWriteSucceeded && HyprMX.getInitializationState() == HyprMXState.INITIALIZATION_COMPLETE) {
             HyprMX.setConsentStatus(consentStatus)
         }
     }

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -786,7 +786,7 @@ class HyprMXAdapter : PartnerAdapter {
      */
     private fun checkHyprMxInitStateAndRun(function: () -> Unit) {
         if (HyprMX.getInitializationState() != HyprMXState.INITIALIZATION_COMPLETE) {
-            PartnerLogController.log(CUSTOM, "Delaying $function until HyprMX SDK initialized.")
+            PartnerLogController.log(CUSTOM, "Ignoring $function until HyprMX SDK has initialized.")
             return
         }
         function()

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation HyprMX adapter mediates HyprMX via the Chartboost Media
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.2.0.2"
+    implementation "com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.2.0.3"
 ```
 
 ## Contributions


### PR DESCRIPTION
The HyprMX SDK throws a an exception when the consent is attempted to be set before it has initialized.
- Added HyprMX init check before using the consent API.
- Updated CHANGELOG, README, and build gradle with adapter version bump.