### PR TITLE
[HB-7211] Add public consent setter to non-TCF-compliant partner adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.6.2.0.5
+- Add function allow publishers to set a boolean consent value for the HyprMX SDK consent info.
+
 ### 4.6.2.0.4
 - Fix memory leaks that could occur when fullscreen ads are shown from an `Activity`.
 

--- a/HyprMXAdapter/build.gradle.kts
+++ b/HyprMXAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.6.2.0.4"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.6.2.0.5"
         buildConfigField("String", "CHARTBOOST_MEDIATION_HYPRMX_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -266,6 +266,22 @@ class HyprMXAdapter : PartnerAdapter {
         }
     }
 
+
+    /**
+     * Set HyprMX user's consent value using a boolean.
+     * This is for publishers to manually set the consent status.
+     * This uses CONSENT_GIVEN for true and CONSENT_DECLINED for false.
+     *
+     * @param context a context that will be passed to the SharedPreferences to set the user consent.
+     * @param consented whether or not the user has consented.
+     */
+    fun setConsentStatus(context: Context, consented: Boolean) {
+        setUserConsentTask(
+            context,
+            if (consented) ConsentStatus.CONSENT_GIVEN else ConsentStatus.CONSENT_DECLINED,
+        )
+    }
+
     /**
      * HyprMX needs a unique generated identifier that needs to be static across sessions.
      * This is passed on SDK initialization.

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -270,7 +270,7 @@ class HyprMXAdapter : PartnerAdapter {
     /**
      * Set HyprMX user's consent value using a boolean.
      * This is for publishers to manually set the consent status.
-     * This uses CONSENT_GIVEN for true and CONSENT_DECLINED for false.
+     * This uses GDPR_CONSENT_GRANTED for true and GDPR_CONSENT_DENIED for false.
      *
      * @param context a context that will be passed to the SharedPreferences to set the user consent.
      * @param applies True if GDPR applies, false otherwise.

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -273,12 +273,18 @@ class HyprMXAdapter : PartnerAdapter {
      * This uses CONSENT_GIVEN for true and CONSENT_DECLINED for false.
      *
      * @param context a context that will be passed to the SharedPreferences to set the user consent.
+     * @param applies True if GDPR applies, false otherwise.
      * @param consented whether or not the user has consented.
      */
-    fun setConsentStatus(context: Context, consented: Boolean) {
-        setUserConsentTask(
+    fun setGdpr(
+        context: Context,
+        applies: Boolean?,
+        consented: Boolean,
+    ) {
+        setGdpr(
             context,
-            if (consented) ConsentStatus.CONSENT_GIVEN else ConsentStatus.CONSENT_DECLINED,
+            applies,
+            if (consented) GdprConsentStatus.GDPR_CONSENT_GRANTED else GdprConsentStatus.GDPR_CONSENT_DENIED,
         )
     }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation HyprMX adapter mediates HyprMX via the Chartboost Media
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.2.0.4"
+    implementation "com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.2.0.5"
 ```
 
 ## Contributions


### PR DESCRIPTION
Add function to adapter configuration class that allows publishers to set a boolean consent value to affect the partner SDK consent info.