### PR TITLE
Fix for HyprMX not being capable of supporting ad queuing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.6.4.0.1
+- Fix for HyprMX not being capable of supporting ad queuing.
+
 ### 4.6.4.0.0
 - This version of the adapter has been certified with HyprMX SDK 6.4.0.
 

--- a/HyprMXAdapter/build.gradle.kts
+++ b/HyprMXAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.6.4.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.6.4.0.1"
         buildConfigField("String", "CHARTBOOST_MEDIATION_HYPRMX_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -394,20 +394,20 @@ class HyprMXAdapter : PartnerAdapter {
         if (loadedPartnerPlacements.contains(request.partnerPlacement)) {
             PartnerLogController.log(LOAD_FAILED)
             return Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNKNOWN))
-        } else {
-            return when (request.format.key) {
-                AdFormat.BANNER.key, "adaptive_banner" -> loadBannerAd(
-                    context,
-                    request,
-                    partnerAdListener
-                )
+        }
 
-                AdFormat.INTERSTITIAL.key -> loadInterstitialAd(request, partnerAdListener)
-                AdFormat.REWARDED.key -> loadRewardedAd(request, partnerAdListener)
-                else -> {
-                    PartnerLogController.log(LOAD_FAILED)
-                    Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
-                }
+        return when (request.format.key) {
+            AdFormat.BANNER.key, "adaptive_banner" -> loadBannerAd(
+                context,
+                request,
+                partnerAdListener
+            )
+
+            AdFormat.INTERSTITIAL.key -> loadInterstitialAd(request, partnerAdListener)
+            AdFormat.REWARDED.key -> loadRewardedAd(request, partnerAdListener)
+            else -> {
+                PartnerLogController.log(LOAD_FAILED)
+                Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_LOAD_FAILURE_UNSUPPORTED_AD_FORMAT))
             }
         }
     }

--- a/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
+++ b/HyprMXAdapter/src/main/java/com/chartboost/mediation/hyprmxadapter/HyprMXAdapter.kt
@@ -107,6 +107,12 @@ class HyprMXAdapter : PartnerAdapter {
          * A lambda to call for failed HyprMX ad shows.
          */
         internal var onShowError: (hyprMXErrors: HyprMXErrors) -> Unit = { _: HyprMXErrors -> }
+
+        /**
+         * A list of fullscreen partner placements that have been loaded. Ad queuing is not supported
+         * with HyprMX due to internal implementation constraints.
+         */
+        private val loadedPartnerPlacements = mutableSetOf<String>()
     }
 
     /**
@@ -146,12 +152,6 @@ class HyprMXAdapter : PartnerAdapter {
      * A map of Chartboost Mediation's listeners for the corresponding load identifier.
      */
     private val listeners = mutableMapOf<String, PartnerAdListener>()
-
-    /**
-     * A list of fullscreen partner placements that have been loaded. Ad queuing is not supported
-     * with HyprMX due to internal implementation constraints.
-     */
-    private val loadedPartnerPlacements = mutableSetOf<String>()
 
     /**
      * Initialize the HyprMX SDK so that it is ready to request ads.
@@ -633,7 +633,6 @@ class HyprMXAdapter : PartnerAdapter {
         listener: PartnerAdListener?,
     ): Result<PartnerAd> {
         PartnerLogController.log(SHOW_STARTED)
-        loadedPartnerPlacements.remove(partnerAd.request.partnerPlacement)
 
         return (partnerAd.ad as? Placement)?.let { placement ->
             suspendCancellableCoroutine { continuation ->
@@ -800,6 +799,7 @@ class HyprMXAdapter : PartnerAdapter {
 
         override fun onAdClosed(placement: Placement, finished: Boolean) {
             PartnerLogController.log(DID_DISMISS)
+            loadedPartnerPlacements.remove(request.partnerPlacement)
             listener?.onPartnerAdDismissed(
                 PartnerAd(
                     ad = placement,

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation HyprMX adapter mediates HyprMX via the Chartboost Media
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.4.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.4.0.1"
 ```
 
 ## Contributions


### PR DESCRIPTION
The HyprMX team confirmed that if an ad of the given "placement" is loaded again prior to showing, their SDK internally replaces the ad.  Therefore, it is not possible to use ad queuing with HyprMX.  For example, this sequence of events is not possible:

LOAD -> LOAD -> SHOW -> SHOW

The second SHOW will result in an error.
