### PR TITLE
Fix for HyprMX not being capable of supporting ad queuing (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 ### 5.6.4.0.0
 - This version of the adapter has been certified with HyprMX SDK 6.4.0.
 - This version of the adapter supports Chartboost Mediation SDK version 5.+.
+- Includes fix for HyprMX not being capable of supporting ad queuing.
+
+### 4.6.4.1.1
+- Fix for HyprMX not being capable of supporting ad queuing.
+
+### 4.6.4.1.0
+- This version of the adapter has been certified with HyprMX SDK 6.4.1.
+
+### 4.6.4.0.0
+- This version of the adapter has been certified with HyprMX SDK 6.4.0.
 
 ### 4.6.2.0.5
 - Add function allow publishers to set a boolean consent value for the HyprMX SDK consent info.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
-### 5.6.4.0.0
-- This version of the adapter has been certified with HyprMX SDK 6.4.0.
+### 5.6.4.1.0
+- This version of the adapter has been certified with HyprMX SDK 6.4.1.
 - This version of the adapter supports Chartboost Mediation SDK version 5.+.
 - Includes fix for HyprMX not being capable of supporting ad queuing.
 

--- a/HyprMXAdapter/build.gradle.kts
+++ b/HyprMXAdapter/build.gradle.kts
@@ -42,7 +42,7 @@ android {
         minSdk = 21
         targetSdk = 34
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.6.4.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "5.6.4.1.0"
         buildConfigField("String", "CHARTBOOST_MEDIATION_HYPRMX_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -90,7 +90,7 @@ dependencies {
 
     // For external usage, please use the following production dependency.
     // You may choose a different release version.
-    implementation("com.hyprmx.android:HyprMX-SDK:6.4.0")
+    implementation("com.hyprmx.android:HyprMX-SDK:6.4.1")
 
     // Partner SDK Dependencies
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation HyprMX adapter mediates HyprMX via the Chartboost Media
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-hyprmx:5.6.4.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-hyprmx:5.6.4.1.0"
 ```
 
 ## Contributions


### PR DESCRIPTION
This is the version of the fix for https://chartboost.atlassian.net/browse/HB-7394 ported from the 4.x SDK (see https://github.com/ChartBoost/chartboost-mediation-android-adapter-hyprmx/pull/24) but for the 5.x SDK.
